### PR TITLE
Fix `document.context` being undefined

### DIFF
--- a/angular-cookie.js
+++ b/angular-cookie.js
@@ -33,7 +33,8 @@
     factory('$cookie', ['$document', function ($document) {
         return (function() {
             function cookieFun(key, value, options) {
-
+                options = options || {};
+                
                 if (value !== undefined) {
                     // we are setting value
                     value = typeof value === 'object' ? JSON.stringify(value) : String(value);
@@ -41,10 +42,17 @@
                     if (typeof options.expires === 'number') {
                         var expiresFor = options.expires;
                         options.expires = new Date();
-                        options.expires.setDate(options.expires.getDate() + expiresFor);
+                        // Trying to delete a cookie; set a date far in the past
+                        if(expiresFor === -1) {
+                            options.expires = new Date('Thu, 01 Jan 1970 00:00:00 GMT');
+                        // A new 
+                        } else {
+                            options.expires.setDate(options.expires.getDate() + expiresFor);    
+                        }
+
                     }   
 
-                    return ($document.context.cookie = [
+                    return ($document[0].cookie = [
                         encodeURIComponent(key),
                         '=',
                         encodeURIComponent(value),
@@ -57,7 +65,7 @@
 
                 // we are getting value
                 var cookies = {}, i, cookie, pos, name;
-                var all = $document.context.cookie;
+                var all = $document[0].cookie;
                 var list = all.split("; ");
                 for(i = 0; i < list.length; ++i) {  
                     if (list[i]) {
@@ -81,7 +89,8 @@
                 return isEmpty(cookies) ? false : cookies;
             }
             cookieFun.remove = function (key, options) {
-
+                options = options || {};
+                
                 if (cookieFun(key) !== undefined) {
                     cookieFun(key, '', extend(options, { expires: -1 }));
                     return true;


### PR DESCRIPTION
Also, add the `options` definition and add a special case for expiry date being -1 (seemed necessary on Chrome Canary but possibly redundant).
