### PR TITLE
Add bower.json install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,18 @@ You can install ``angular-cookie`` via bower
 bower install angular-cookie
 ```
 
+Or, if you want to add your ``angular-cookie`` dependency to your `bower.json`
+
+```
+{
+  devDependencies: {
+    "angular-cookie": ""
+  }
+}
+```
+
+After updating your `bower.json` dependencies, you can run `bower install`.
+
 Other way to install ``angular-cookie`` is to clone this repo into you project with this command
 
 ```


### PR DESCRIPTION
Currently, `bower install` only works with `bower.json` if there's only an empty string for the version inside `devDependencies`.  I figure many people will want to add to their `bower.json` and use `bower install` rather than just `bower install angular-cookie`.  What are your thoughts?
