### PR TITLE
fix breaking typo and encode strings

### DIFF
--- a/angular-cookie.js
+++ b/angular-cookie.js
@@ -51,11 +51,11 @@ factory('ipCookie', ['$document', function ($document) {
                     encodeURIComponent(key),
                     '=',
                     encodeURIComponent(value),
-                    options.expires ? '; expires=' + options.expires.toUTCString() : '',
-                    options.path    ? '; path=' + options.path : '',
-                    options.domain  ? '; domain=' + options.domain : '',
-                    options.secure  ? '; secure' : ''
-                    ].join('')); 
+                    options.expires ? ('; expires=' + options.expires).toUTCString() : '',
+                    options.path    ? ('; path=' + options.path).toUTCString() : '',
+                    options.domain  ? ('; domain=' + options.domain).toUTCString() : '',
+                    options.secure  ? ('; secure').toUTCString() : ''
+                ].join('')); 
             }
 
             list = [];


### PR DESCRIPTION
I tried using `{expires: numDays}` in my project with `angular-cookie`.  However, it appears that it doesn't work!!  I just found out that it doesn't work because the `;` is not encoded.  Therefore, none of the options are actually appended to the cookie string.  The browser will completely curtail any un-encoded characters and any characters afterward.  My fix here should address the encoding problem.  What are your thoughts?
