### PR TITLE
Allow defaults via provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,13 +20,13 @@ git clone git@github.com:ivpusic/angular-cookie.git
 
 Then you need to include ``angular-cookie.js`` script into your project
 
-```
+```html
 <script src="/path/to/angular-cookie.min.js"></script>
 ```
 
 or include `beautified` version with
 
-```
+```html
 <script src="/path/to/angular-cookie.js"></script>
 ```
 
@@ -58,12 +58,12 @@ Usage
 
 First you need to inject ``ipCookie`` into your angular module.
 
-```
+```javascript
 var myApp = angular.module('myApp', ['ipCookie']);
 ```
 And now, for example if you want to use it from your controller
 
-```
+```javascript
 myApp.controller('cookieController', ['$scope', 'ipCookie', function($scope, ipCookie) {
   // your code here
 }]);
@@ -71,7 +71,7 @@ myApp.controller('cookieController', ['$scope', 'ipCookie', function($scope, ipC
 
 General signature of main function is
 
-```
+```javascript
 ipCookie(key, value, options);
 ```
 
@@ -79,7 +79,7 @@ ipCookie(key, value, options);
 
 To create a cookie use
 
-```
+```javascript
 ipCookie(key, value);
 ```
 
@@ -87,13 +87,13 @@ The `value` supports strings, numbers, booleans, arrays and objects and will be 
 
 You can also set some additional options, like number of day when a cookie expires
 
-```
+```javascript
 ipCookie(key, value, { expires: 21 });
 ```
 
 If you want to specify a cookie path use
 
-```
+```javascript
 ipCookie(key, value, { path: '/some/path' });
 ```
 
@@ -101,13 +101,13 @@ ipCookie(key, value, { path: '/some/path' });
 
 To get all cookies use
 
-```
+```javascript
 ipCookie();
 ```
 
 If you want to get a cookie with a specific key use
 
-```
+```javascript
 ipCookie(key);
 ```
 
@@ -119,13 +119,13 @@ The returned value will be automatically deserialized.
 
 And if you want to remove a cookie use
 
-```
+```javascript
 ipCookie.remove(key);
 ```
 
 To remove a cookie on a specific path use
 
-```
+```javascript
 ipCookie.remove(key, { path: '/some/path/' });
 ```
 
@@ -176,6 +176,19 @@ secure: true
 
 The Secure attribute is meant to keep cookie communication limited to encrypted transmission, 
 directing browsers to use cookies only via secure/encrypted connections.
+
+
+## Defaults
+To set defaults for the options you can use the ``ipCookieProvider`` as follows:
+
+```javascript
+myApp.config(['ipCookieProvider', function(ipCookieProvider) {
+	ipCookieProvider.setDefaults({
+		path: '/',
+		expires: 21
+	});
+}]);
+```
 
 ## Notes
 - String (only digits) encoding -> [check this PR](https://github.com/ivpusic/angular-cookie/pull/29)

--- a/angular-cookie.js
+++ b/angular-cookie.js
@@ -3,14 +3,21 @@
  * Contributors:
  *   Matjaz Lipus
  */
-(function (window, angular, undefined) {
+(function(window, angular, undefined) {
 	'use strict';
 
 	angular.module('ivpusic.cookie', ['ipCookie']);
 	angular.module('ipCookie', ['ng']).
-	provider('ipCookie', function () {
+	provider('ipCookie', function() {
+		var defaults = {
+		};
+
+		this.setDefaults = function(newDefaults) {
+			angular.extend(defaults, newDefaults);
+		};
+
 		this.$get = ['$document',
-			function ($document) {
+			function($document) {
 
 				function cookieFun(key, value, options) {
 
@@ -24,7 +31,7 @@
 					  all,
 					  expiresFor;
 
-					options = options || {};
+					options = angular.extend({}, defaults, options);
 
 					if (value !== undefined) {
 						// we are setting value
@@ -95,7 +102,7 @@
 						return cookies;
 					}
 				}
-				cookieFun.remove = function (key, options) {
+				cookieFun.remove = function(key, options) {
 					var hasCookie = cookieFun(key) !== undefined;
 
 					if (hasCookie) {

--- a/angular-cookie.js
+++ b/angular-cookie.js
@@ -3,109 +3,114 @@
  * Contributors:
  *   Matjaz Lipus
  */
-angular.module('ivpusic.cookie', ['ipCookie']);
-angular.module('ipCookie', ['ng']).
-factory('ipCookie', ['$document',
-  function ($document) {
-    'use strict';
+(function (window, angular, undefined) {
+	'use strict';
 
-    return (function () {
-      function cookieFun(key, value, options) {
+	angular.module('ivpusic.cookie', ['ipCookie']);
+	angular.module('ipCookie', ['ng']).
+	provider('ipCookie', function () {
+		this.$get = ['$document',
+			function ($document) {
 
-        var cookies,
-          list,
-          i,
-          cookie,
-          pos,
-          name,
-          hasCookies,
-          all,
-          expiresFor;
+				function cookieFun(key, value, options) {
 
-        options = options || {};
+					var cookies,
+					  list,
+					  i,
+					  cookie,
+					  pos,
+					  name,
+					  hasCookies,
+					  all,
+					  expiresFor;
 
-        if (value !== undefined) {
-          // we are setting value
-          value = typeof value === 'object' ? JSON.stringify(value) : String(value);
+					options = options || {};
 
-          if (typeof options.expires === 'number') {
-            expiresFor = options.expires;
-            options.expires = new Date();
-            // Trying to delete a cookie; set a date far in the past
-            if (expiresFor === -1) {
-              options.expires = new Date('Thu, 01 Jan 1970 00:00:00 GMT');
-              // A new 
-            } else if (options.expirationUnit !== undefined) {
-              if (options.expirationUnit === 'hours') {
-                options.expires.setHours(options.expires.getHours() + expiresFor);
-              } else if (options.expirationUnit === 'minutes') {
-                options.expires.setMinutes(options.expires.getMinutes() + expiresFor);
-              } else if (options.expirationUnit === 'seconds') {
-                options.expires.setSeconds(options.expires.getSeconds() + expiresFor);
-              } else {
-                options.expires.setDate(options.expires.getDate() + expiresFor);
-              }
-            } else {
-              options.expires.setDate(options.expires.getDate() + expiresFor);
-            }
-          }
-          return ($document[0].cookie = [
-            encodeURIComponent(key),
-            '=',
-            encodeURIComponent(value),
-            options.expires ? '; expires=' + options.expires.toUTCString() : '',
-            options.path ? '; path=' + options.path : '',
-            options.domain ? '; domain=' + options.domain : '',
-            options.secure ? '; secure' : ''
-          ].join(''));
-        }
+					if (value !== undefined) {
+						// we are setting value
+						value = typeof value === 'object' ? JSON.stringify(value) : String(value);
 
-        list = [];
-        all = $document[0].cookie;
-        if (all) {
-          list = all.split('; ');
-        }
+						if (typeof options.expires === 'number') {
+							expiresFor = options.expires;
+							options.expires = new Date();
+							// Trying to delete a cookie; set a date far in the past
+							if (expiresFor === -1) {
+								options.expires = new Date('Thu, 01 Jan 1970 00:00:00 GMT');
+								// A new 
+							} else if (options.expirationUnit !== undefined) {
+								if (options.expirationUnit === 'hours') {
+									options.expires.setHours(options.expires.getHours() + expiresFor);
+								} else if (options.expirationUnit === 'minutes') {
+									options.expires.setMinutes(options.expires.getMinutes() + expiresFor);
+								} else if (options.expirationUnit === 'seconds') {
+									options.expires.setSeconds(options.expires.getSeconds() + expiresFor);
+								} else {
+									options.expires.setDate(options.expires.getDate() + expiresFor);
+								}
+							} else {
+								options.expires.setDate(options.expires.getDate() + expiresFor);
+							}
+						}
+						return ($document[0].cookie = [
+						  encodeURIComponent(key),
+						  '=',
+						  encodeURIComponent(value),
+						  options.expires ? '; expires=' + options.expires.toUTCString() : '',
+						  options.path ? '; path=' + options.path : '',
+						  options.domain ? '; domain=' + options.domain : '',
+						  options.secure ? '; secure' : ''
+						].join(''));
+					}
 
-        cookies = {};
-        hasCookies = false;
+					list = [];
+					all = $document[0].cookie;
+					if (all) {
+						list = all.split('; ');
+					}
 
-        for (i = 0; i < list.length; ++i) {
-          if (list[i]) {
-            cookie = list[i];
-            pos = cookie.indexOf('=');
-            name = cookie.substring(0, pos);
-            value = decodeURIComponent(cookie.substring(pos + 1));
+					cookies = {};
+					hasCookies = false;
 
-            if (key === undefined || key === name) {
-              try {
-                cookies[name] = JSON.parse(value);
-              } catch (e) {
-                cookies[name] = value;
-              }
-              if (key === name) {
-                return cookies[name];
-              }
-              hasCookies = true;
-            }
-          }
-        }
-        if (hasCookies && key === undefined) {
-          return cookies;
-        }
-      }
-      cookieFun.remove = function (key, options) {
-        var hasCookie = cookieFun(key) !== undefined;
+					for (i = 0; i < list.length; ++i) {
+						if (list[i]) {
+							cookie = list[i];
+							pos = cookie.indexOf('=');
+							name = cookie.substring(0, pos);
+							value = decodeURIComponent(cookie.substring(pos + 1));
 
-        if (hasCookie) {
-          if (!options) {
-            options = {};
-          }
-          options.expires = -1;
-          cookieFun(key, '', options);
-        }
-        return hasCookie;
-      };
-      return cookieFun;
-    }());
-  }
-]);
+							if (key === undefined || key === name) {
+								try {
+									cookies[name] = JSON.parse(value);
+								} catch (e) {
+									cookies[name] = value;
+								}
+								if (key === name) {
+									return cookies[name];
+								}
+								hasCookies = true;
+							}
+						}
+					}
+					if (hasCookies && key === undefined) {
+						return cookies;
+					}
+				}
+				cookieFun.remove = function (key, options) {
+					var hasCookie = cookieFun(key) !== undefined;
+
+					if (hasCookie) {
+						if (!options) {
+							options = {};
+						}
+						options.expires = -1;
+						cookieFun(key, '', options);
+					}
+					return hasCookie;
+				};
+				return cookieFun;
+
+			}
+		];
+
+	});
+})(window, window.angular);


### PR DESCRIPTION
Looks like alot has changed, but I've pretty much just put everything that was there in the _this.$get_ property of the provider as opposed to using the shortcut _factory_ method. This allows me to expose the _setDefaults()_ function on the provider.

Mostly useful to be able to set the default path or expires options so you don't have to provide them on every call to ipCookie. Didn't include the minfied file as I assume you'd want to change version numbers etc.
