### PR TITLE
Encoding should be enforced on key while using a get

### DIFF
--- a/angular-cookie.js
+++ b/angular-cookie.js
@@ -93,6 +93,7 @@ factory('ipCookie', ['$document',
                 cookies[name] = value;
               }
               if (key === name) {
+                name=encodeURIComponent(name);
                 return cookies[name];
               }
               hasCookies = true;
@@ -104,6 +105,7 @@ factory('ipCookie', ['$document',
         }
       }
       cookieFun.remove = function (key, options) {
+        key=encodeURIComponent(key);
         var hasCookie = cookieFun(key) !== undefined;
 
         if (hasCookie) {


### PR DESCRIPTION
Change to angular-cookie.js
ipCookie will not be able to fetch values stored in cookie if the key is not encoded while fetching. Correct me if am wrong