### PR TITLE
Optional change encode and decode functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,12 @@ If you want to specify a cookie path use
 ipCookie(key, value, { path: '/some/path' });
 ```
 
+If you want to set the encode or decode functions use
+
+```
+ipCookie(key, value, { encode: function (value) { return value; } });
+```
+
 #### Get
 
 To get all cookies use
@@ -114,6 +120,12 @@ ipCookie(key);
 If any cookie was not found, function returns ``undefined``.
 
 The returned value will be automatically deserialized.
+
+If you want to pass an options object, you will need to also pass 'undefined' as the second parameter:
+
+```
+ipCookie(key, undefined, {decode: function (value) { return value; }};
+```
 
 #### Remove
 
@@ -176,6 +188,26 @@ secure: true
 
 The Secure attribute is meant to keep cookie communication limited to encrypted transmission, 
 directing browsers to use cookies only via secure/encrypted connections.
+
+#### Encode function
+
+```
+encode: function (value) { return value; }
+```
+
+The method that will be used to encode the cookie value (should be passed when using Set).
+
+Default: encodeURIComponent.
+
+#### Decode function
+
+```
+decode: function (value) { return value; }
+```
+
+The method that will be used to decode extracted cookie values (should be passed when using Get).
+
+Default: decodeURIComponent.
 
 ## Notes
 - String (only digits) encoding -> [check this PR](https://github.com/ivpusic/angular-cookie/pull/29)

--- a/angular-cookie.js
+++ b/angular-cookie.js
@@ -31,6 +31,8 @@ factory('ipCookie', ['$document',
           expiresFor;
 
         options = options || {};
+        var dec = options.decode || tryDecodeURIComponent;
+        var enc = options.encode || encodeURIComponent;
 
         if (value !== undefined) {
           // we are setting value
@@ -58,9 +60,9 @@ factory('ipCookie', ['$document',
             }
           }
           return ($document[0].cookie = [
-            encodeURIComponent(key),
+            enc(key),
             '=',
-            encodeURIComponent(value),
+            enc(value),
             options.expires ? '; expires=' + options.expires.toUTCString() : '',
             options.path ? '; path=' + options.path : '',
             options.domain ? '; domain=' + options.domain : '',
@@ -82,7 +84,7 @@ factory('ipCookie', ['$document',
             cookie = list[i];
             pos = cookie.indexOf('=');
             name = cookie.substring(0, pos);
-            value = tryDecodeURIComponent(cookie.substring(pos + 1));
+            value = dec(cookie.substring(pos + 1));
             if(angular.isUndefined(value))
               continue;
 


### PR DESCRIPTION
Add the ability to change the encode and decode functions by passing
those functions in the option parameter.

Getter example:
ipCookie('cookieName', undefined, { decode: angular.identity, encode:
angular.identity });

Setter example:
ipCookie('cookieName', 'http://test.com/#/', { decode:
angular.identity, encode: angular.identity });