### PR TITLE
Move development dependancies to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "example": "example",
     "test": "test"
   },
-  "dependencies": {
+  "devDependencies": {
     "grunt-contrib-connect": "^0.5.0",
     "grunt": "^0.4.5",
     "bower": "^1.3.12",
@@ -15,9 +15,7 @@
     "lodash": "^3.10.0",
     "install": "^0.1.7",
     "npm": "^1.3.26",
-    "require": "^0.5.0"
-  },
-  "devDependencies": {
+    "require": "^0.5.0",
     "mocha": "^1.20.1"
   },
   "scripts": {


### PR DESCRIPTION
You don't depend on bower, lodash, grunt etc in production