### PR TITLE
Add support for NodeJS-style require

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,2 @@
+require('./angular-cookie');
+module.exports = 'ipCookie';

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "angular-cookie",
   "version": "4.0.10",
   "description": "Lightweight Angular module for access to cookies",
-  "main": "angular-cookie.js",
+  "main": "index.js",
   "directories": {
     "example": "example",
     "test": "test"


### PR DESCRIPTION
This makes it easier to integrate with tools that use NodeJS packages, like webpack and browserify. This also makes the style of this package consistent with native Angular packages distributed through npm, e.g.

```javascript
angular.module('myApp', [require('angular-cookie')]);`
```