### PR TITLE
Fix options object being modified 

### DIFF
--- a/angular-cookie.js
+++ b/angular-cookie.js
@@ -30,7 +30,7 @@ factory('ipCookie', ['$document',
           all,
           expiresFor;
 
-        options = options || {};
+        options = angular.extend({}, options);
         var dec = options.decode || tryDecodeURIComponent;
         var enc = options.encode || encodeURIComponent;
 


### PR DESCRIPTION
If the user does ipCookie.remove and has its expires options updated to an expiry date, then the next time they save, that options object has been replaced by the expired date. 

Not modifying user’s options would be best. 